### PR TITLE
Added functionality for approving (adding) laws.

### DIFF
--- a/IN.sol
+++ b/IN.sol
@@ -81,7 +81,9 @@ contract Laws {
         lawCount += 1;
     }
 
-    // This modifier checks for conditions...
+    // This modifier checks for conditions:
+    // 1. law struct has to not already be includes
+    // 2. the governance contract does not reject this type of law (for reasons unknown)
     modifier checkProposedLaw(address _associatedContract) {
         emit Log("Modifier checking for proposed law conditions.");
         require(laws[_associatedContract].status == 0,"This law contract is already in the map!");
@@ -89,4 +91,23 @@ contract Laws {
         require(how.notifyOfProposedLaw(_associatedContract),"HowContract returned FALSE. Rejects law proposal." );
         _;
     }
+
+    // This function certifies a previously added law structure to be accepted as a law
+    function addLaw(address _associatedContract)  external
+    checkAddingLaw(_associatedContract)
+    {
+        laws[_associatedContract].status = 2;
+    }
+
+    // This modifier checks for conditions:
+    // 1. the law this struct represents has to have been proposed first
+    // 2. the governance contract has to approve the _specific_ law
+    modifier checkAddingLaw(address _associatedContract) {
+        emit Log("Modifier checking for proposed law conditions.");
+        require(laws[_associatedContract].status == 1,"This law contract is not a proposed law!");
+        GovernContract how = GovernContract(governContractAddr);    // creates local instance from reference to existing
+        require(how.notifyOfApprovingLaw(_associatedContract),"HowContract returned FALSE. Rejects law addition." );
+        _;
+    }
+
 }

--- a/INhow_Interface.sol
+++ b/INhow_Interface.sol
@@ -14,6 +14,12 @@ interface GovernContract {
     // (It is meant to return "true" if everything went well; things can go wrong, like proposing a law twice.)
     function notifyOfProposedLaw(address associatedLawContract) external returns (bool);
 
+    // a function to notify this governance contract to dictate if a proposed law has been approved
+    // (It is meant to return "true" if this _specific_ law is approved and "false" if not. The key factor
+    // here is the specificity of the contract to be approved; the governance contract can keep track of what
+    // this means, and also who is performing this interaction/transaction.)
+    function notifyOfApprovingLaw(address associatedLawContract) external returns (bool);
+
     // a function that is meant to return "true" used for debugging
     // This function is useful for testing when using a "require()" inside another smart contract.
     // For example, suppose contract "ProcessContract" uses this "HowContract" to determine the

--- a/INhow_byvote.sol
+++ b/INhow_byvote.sol
@@ -31,9 +31,17 @@ contract GovernContract_ByVote is GovernContract {
         return false;
     }
 
+    // a function that is asked to accept a law as having been proposed
     function notifyOfProposedLaw(address associatedLawContract) external returns (bool) {
         emit LogAddress("The contract was notified of a proposed law", associatedLawContract);
         // Always "reject" for now
+        return false;
+    }
+
+    // a function that is asked to specify if a law is to be approved
+    // (The incoming law contract address can be used to check for the _specific_ law to be approved.)
+    function notifyOfApprovingLaw(address associatedLawContract) external returns (bool) {
+        emit LogAddress("The contract was notified to approve a law", associatedLawContract);
         return false;
     }
 

--- a/INhow_default.sol
+++ b/INhow_default.sol
@@ -63,10 +63,20 @@ contract GovernContract_Default is GovernContract {
         allowedContractAddr = newDecisonContractAddr;
     }
 
+    // a function that is asked to accept a law as having been proposed
     function notifyOfProposedLaw(address associatedLawContract) external returns (bool) {
         emit LogAddress("The dictatorship was notified of a proposed law", associatedLawContract);
         // Always "accept" any proposed laws, even though dicators seldom regard opinions...
         return true;
+    }
+
+    // a function that is asked to specify if a law is to be approved
+    // (The incoming law contract address can be used to check for the _specific_ law to be approved.)
+    function notifyOfApprovingLaw(address associatedLawContract) external returns (bool) {
+        emit LogAddress("The dictatorship was notified to approve a law", associatedLawContract);
+        // Only accept if the approver is the dictator, regardless of what contract this is
+        if(msg.sender == dictatorAddr) return true;
+        return false;
     }
 
 //--- these functions are for DEBUGGING


### PR DESCRIPTION
Added the method "addLaw()" to the "Laws" contract, which is supposed to
check the governance contract for approving a _specific_ law. It is guarded by the modifier "checkAddingLaw()". On success, it changes the "status" member of the law struct to "2", to indicate that this law is approved in the laws of this country. The modifier "checkAddingLaw()" first checks that the associated law contract address is already a proposed law (checks the "status" member for being "1"), and then ask the governance contract for whether this _specific_ law has been approved. (NOTE: unapproved laws now remain in the map, and a clean-up method may be added in the future.)

The interface to the governance contract "INhow_Interface.sol" has been augmented with the function "notifyOfApprovingLaw()", which is a method that is meant to ask the governance contract for whether a _specific_ law has been approved. (The governance contract could have kept track of what laws have been proposed, but it does not have to.)

The "dictatorship" contract in "INhow_default.sol" has been augmented with the method "notifyOfApprovingLaw()" as required by the parent interface. It disregards the incoming law contract address, but checks for whether this interaction is performed by the internally stored "dictarorAddr", and if so, it returns "true". (Essentially, an interaction by the dictator approves any law.)

The (non-functional) "democracy" contract has been augmented with the method "notifyOfApprovingLaw()" such that it compiles; it always rejects laws by returing false (for now).
IN 2023/08/07